### PR TITLE
Add Docker-based run target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+client/node_modules
+server/node_modules
+uploads
+*.log
+*.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Build React app
+FROM node:18 as build
+
+WORKDIR /app
+
+# install client deps and build
+COPY client/package*.json ./client/
+RUN cd client && npm install
+COPY client ./client
+RUN cd client && npm run build
+
+# production image
+FROM node:18
+WORKDIR /app
+
+# install server deps
+COPY server/package*.json ./server/
+RUN cd server && npm install
+
+COPY server ./server
+COPY --from=build /app/client/build ./client/build
+
+WORKDIR /app/server
+ENV NODE_ENV=production
+ENV PORT=80
+EXPOSE 80
+CMD ["node", "server.js"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+IMAGE_NAME=website-tst
+
+run:
+	docker build -t $(IMAGE_NAME) .
+	docker run --rm -p 80:80 $(IMAGE_NAME)

--- a/readme.md
+++ b/readme.md
@@ -18,5 +18,14 @@ npm install
 npm start
 ```
 
+### Docker
+
+You can also run the entire application in Docker. This will build the React
+app and start the Node server listening on port 80:
+
+```bash
+make run
+```
+
 Add any favicon or logo images you want to use into `client/public` and update
 `index.html` and `manifest.json` accordingly.

--- a/server/server.js
+++ b/server/server.js
@@ -72,4 +72,13 @@ app.get('/api/photos', isLoggedIn, (req, res) => {
 
 app.use('/uploads', express.static(uploadDir));
 
+// Serve the React build if it exists
+const buildPath = path.join(__dirname, '..', 'client', 'build');
+if (fs.existsSync(buildPath)) {
+  app.use(express.static(buildPath));
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(buildPath, 'index.html'));
+  });
+}
+
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- serve built React client from Node server when present
- add Dockerfile and `.dockerignore` for containerized deployment
- provide Makefile with `run` target to build and start container on port 80
- document Docker usage

## Testing
- `npm install` in `client` and run `npm test -- --watchAll=false`
- `npm install` in `server`
- ❌ `docker build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695daea044832a8571edf8b25422fa