### PR TITLE
Fix wildcard route error in Express 5

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -76,7 +76,9 @@ app.use('/uploads', express.static(uploadDir));
 const buildPath = path.join(__dirname, '..', 'client', 'build');
 if (fs.existsSync(buildPath)) {
   app.use(express.static(buildPath));
-  app.get('*', (req, res) => {
+  // Express 5 uses path-to-regexp@6 which does not support a bare "*" path.
+  // Using "/*" matches any path so the React app can handle client-side routes.
+  app.get('/*', (req, res) => {
     res.sendFile(path.join(buildPath, 'index.html'));
   });
 }


### PR DESCRIPTION
## Summary
- update wildcard route in `server.js` for compatibility with Express 5

## Testing
- `npm test --silent -- --watchAll=false` in `client`
- `npm test --silent` in `server`
- `node server/server.js`

------
https://chatgpt.com/codex/tasks/task_e_68695fcc1164832a8a853d838fdc40b2