### PR TITLE
Add drive refresh UI and server endpoints

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -3,20 +3,28 @@
   text-align: center;
   background: #e6ffe6;
   min-height: 100vh;
-  padding: 20px;
+  padding: 20px 40px;
 }
 
 h1 {
   color: #2e7d32;
 }
 
-.login, .upload {
+.login, .upload, .drive-manager {
   margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 input, button {
   margin: 5px;
   padding: 8px;
+}
+
+.drive-manager ul {
+  list-style: none;
+  padding: 0;
 }
 
 .gallery {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,69 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
 
+function DriveManager() {
+  const [info, setInfo] = useState({ sdReader: false, mounts: [] });
+  const [device, setDevice] = useState('');
+  const [mountpoint, setMountpoint] = useState('');
+
+  const refresh = async () => {
+    const res = await fetch('http://localhost:5000/api/drives');
+    if (res.ok) {
+      const data = await res.json();
+      setInfo(data);
+    }
+  };
+
+  const handleMount = async () => {
+    const res = await fetch('http://localhost:5000/api/mount', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ device, mountpoint })
+    });
+    if (res.ok) {
+      setDevice('');
+      setMountpoint('');
+      refresh();
+    } else {
+      alert('Mount failed');
+    }
+  };
+
+  useEffect(() => { refresh(); }, []);
+
+  return (
+    <div className="drive-manager">
+      <button onClick={refresh}>Refresh Drives</button>
+      {info.sdReader && info.mounts.length === 0 && (
+        <div>
+          <p>SD card reader detected but not mounted.</p>
+          <input
+            placeholder="Device path"
+            value={device}
+            onChange={e => setDevice(e.target.value)}
+          />
+          <input
+            placeholder="Mount point"
+            value={mountpoint}
+            onChange={e => setMountpoint(e.target.value)}
+          />
+          <button onClick={handleMount}>Mount</button>
+        </div>
+      )}
+      {info.mounts.length > 0 && (
+        <div>
+          <p>Mounted devices in /media:</p>
+          <ul>
+            {info.mounts.map(m => (
+              <li key={m}>{m}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function Login({ onLogin }) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
@@ -48,6 +111,7 @@ function Gallery() {
   };
   return (
     <div>
+      <DriveManager />
       <form onSubmit={handleUpload} className="upload">
         <input type="file" onChange={e => setFile(e.target.files[0])} />
         <button type="submit">Upload</button>


### PR DESCRIPTION
## Summary
- detect drives and allow mounting through new DriveManager UI
- display Refresh button and device lists in the React app
- style forms and new component with better spacing
- expose `/api/drives` and `/api/mount` endpoints on the server

## Testing
- `npm test --prefix client --silent`

------
https://chatgpt.com/codex/tasks/task_e_686961a68810832ab72ea50dd517bccc