### PR TITLE
Fix admin login and store database in dedicated folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,6 @@ node_modules
 client/node_modules
 server/node_modules
 uploads
+server/database
 *.log
 *.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 uploads
+server/database
 *.log
 *.db

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ IMAGE_NAME=website-tst
 
 run:
 	docker build -t $(IMAGE_NAME) .
-	docker run --rm -p 80:80 $(IMAGE_NAME)
+	docker run --rm -p 80:80 -v $(PWD)/server/database:/app/server/database $(IMAGE_NAME)

--- a/server/server.js
+++ b/server/server.js
@@ -14,7 +14,9 @@ app.use(cors({ origin: 'http://localhost:3000', credentials: true }));
 app.use(express.json());
 app.use(session({ secret: 'secret', resave: false, saveUninitialized: false }));
 
-const db = new sqlite3.Database(path.join(__dirname, 'database.db'));
+const dbDir = path.join(__dirname, 'database');
+if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir);
+const db = new sqlite3.Database(path.join(dbDir, 'database.db'));
 
 db.serialize(() => {
   db.run('CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT)');


### PR DESCRIPTION
## Summary
- create a dedicated `server/database` folder
- ensure the folder exists at startup and store `database.db` there
- ignore the `server/database` folder in git and docker build
- mount the database directory when running the docker image

## Testing
- `npm install` in `server`
- `npm install` and `npm run build` in `client`
- `node server.js` then login via curl
- `make run` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696bc0ab50832a851c400cfe80c6b2